### PR TITLE
Ensure records do not get stuck in processing state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Changed:
 
 - `AsyncioDispatcher cleanup tasks atexit <../../pull/138>`_
 - `Ensure returned numpy arrays are not writeable <../../pull/164>`_
+- `Ensure records do not get stuck in processing state <../../pull/175>`_
 
 Fixed:
 

--- a/softioc/asyncio_dispatcher.py
+++ b/softioc/asyncio_dispatcher.py
@@ -84,10 +84,11 @@ class AsyncioDispatcher:
                 ret = func(*func_args)
                 if inspect.isawaitable(ret):
                     await ret
-                if completion:
-                    completion(*completion_args)
             except Exception:
                 logging.exception("Exception when running dispatched callback")
+            finally:
+                if completion:
+                    completion(*completion_args)
         asyncio.run_coroutine_threadsafe(async_wrapper(), self.loop)
 
     def __enter__(self):

--- a/softioc/cothread_dispatcher.py
+++ b/softioc/cothread_dispatcher.py
@@ -1,3 +1,5 @@
+import inspect
+import logging
 
 class CothreadDispatcher:
     def __init__(self, dispatcher = None):
@@ -28,7 +30,12 @@ class CothreadDispatcher:
             completion = None,
             completion_args=()):
         def wrapper():
-            func(*func_args)
-            if completion:
-                completion(*completion_args)
+            try:
+                func(*func_args)
+            except Exception:
+                logging.exception("Exception when running dispatched callback")
+            finally:
+                if completion:
+                    completion(*completion_args)
+
         self.__dispatcher(wrapper)

--- a/softioc/cothread_dispatcher.py
+++ b/softioc/cothread_dispatcher.py
@@ -38,4 +38,7 @@ class CothreadDispatcher:
                 if completion:
                     completion(*completion_args)
 
+        assert not inspect.iscoroutinefunction(func)
+        assert not inspect.iscoroutinefunction(completion)
+
         self.__dispatcher(wrapper)


### PR DESCRIPTION
If an exception occurs during an on_update callback, the "completion" function would never be called, which meant the PACT flag was never reset.

This had the end result of causing the affected record to never process again, i.e. its value could never be changed.

Also took the opportunity to add some protection to the cothread dispatcher against being passed and async function.

Fixes #170