### PR TITLE
Fix linter by using recent Python version

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.7"
+          python-version: "3.12"
 
       - name: Install Python Dependencies
         run: pip install flake8

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   build:
     name: "Docs CI"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Source

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,9 +62,12 @@ dev =
 [flake8]
 max-line-length = 80
 extend-ignore =
-    F401 F403 F405  # Allow from module import *
-    E251  # Allow call(param = value)
-    E301 E302 E303 E305 # Allow any number of blank lines
+    # Allow from module import *
+    F401 F403 F405
+    # Allow call(param = value)
+    E251
+    # Allow any number of blank lines
+    E301 E302 E303 E305
 
 [tool:pytest]
 # Run pytest with all our checkers, and don't spam us with massive tracebacks on error

--- a/softioc/builder.py
+++ b/softioc/builder.py
@@ -324,7 +324,6 @@ def ClearRecords():
 
 SetSimpleRecordNames(None, ':')
 
-SetDeviceName = SetPrefix
 def SetDeviceName(name):
     SetPrefix(name)
 

--- a/tests/test_record_values.py
+++ b/tests/test_record_values.py
@@ -294,7 +294,7 @@ def record_value_asserts(
     # This function is shared between functions that may pass in either a
     # native Python type, or the value returned from p4p, which must be
     # unwrapped
-    if type(actual_value) == p4p.nt.enum.ntenum:
+    if type(actual_value) is p4p.nt.enum.ntenum:
         actual_val_type = type(actual_value.raw["value"].get("index"))
     elif isinstance(actual_value, p4p.nt.scalar.ntwrappercommon):
         actual_val_type = type(actual_value.raw["value"])
@@ -302,7 +302,7 @@ def record_value_asserts(
         actual_val_type = type(actual_value)
 
     try:
-        if type(expected_value) == float and isnan(expected_value):
+        if type(expected_value) is float and isnan(expected_value):
             assert isnan(actual_value)  # NaN != Nan, so needs special case
         elif creation_func in [builder.WaveformOut, builder.WaveformIn]:
             assert numpy.array_equal(actual_value, expected_value)


### PR DESCRIPTION
This PR fixes issues in the Docs and Code-lint stages of the CI.

The lint step has been updated to Python 3.12, along with fixing some minor issues it raised.

The Docs workflow has been pinned to an older Ubuntu version, as it is more work to update the Docs to a more recent Python version given our current reliance on the Pipfile.lock deployment mechanism.