### PR TITLE
Fix releasing wheels for all platforms

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -149,8 +149,9 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with:
-          name: dist
+          pattern: dist*
           path: dist
+          merge-multiple: true
 
       - name: Github Release
         # We pin to the SHA, not the tag, for security reasons.


### PR DESCRIPTION
An after-effect of PR #163 means that artifacts now have unique names per job.
We have to ensure we download all of them to release all wheels.

Fixes #188