### PR TITLE
Add required configuration for pytest-codecov 7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -82,3 +82,4 @@ asyncio_mode = auto
 [coverage:run]
 # This is covered in the versiongit test suite so exclude it here
 omit = */_version_git.py
+patch = subprocess

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ def enable_code_coverage():
     try:
         from pytest_cov.embed import cleanup_on_sigterm
     except ImportError:
-        pass
+        pass  # Note that pytest_cov.embed no longer exists in pytest_cov>=7.0.0
     else:
         cleanup_on_sigterm()
 

--- a/tests/sim_asyncio_ioc.py
+++ b/tests/sim_asyncio_ioc.py
@@ -54,8 +54,12 @@ if __name__ == "__main__":
         conn.send("R")  # "Ready"
 
         # Make sure coverage is written on epicsExit
-        from pytest_cov.embed import cleanup
-        sys._run_exitfuncs = cleanup
+        try:
+            from pytest_cov.embed import cleanup
+            sys._run_exitfuncs = cleanup
+        except ImportError:
+            # Note that pytest_cov.embed no longer exists in pytest_cov>=7.0.0
+            pass
 
         select_and_recv(conn, "D")  # "Done"
         # Attempt to ensure all buffers flushed - C code (from `import pvlog`)

--- a/tests/sim_asyncio_ioc_override.py
+++ b/tests/sim_asyncio_ioc_override.py
@@ -46,8 +46,12 @@ if __name__ == "__main__":
         conn.send("R")  # "Ready"
 
         # Make sure coverage is written on epicsExit
-        from pytest_cov.embed import cleanup
-        sys._run_exitfuncs = cleanup
+        try:
+            from pytest_cov.embed import cleanup
+            sys._run_exitfuncs = cleanup
+        except ImportError:
+            # Note that pytest_cov.embed no longer exists in pytest_cov>=7.0.0
+            pass
 
         select_and_recv(conn, "D")  # "Done"
         # Attempt to ensure all buffers flushed - C code (from `import pvlog`)


### PR DESCRIPTION
In 7.0.0 pytest-cov removed its custom handling of subprocess handling. Instead we now use coverage's system.